### PR TITLE
Rename gems key to plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ logo: # path of site logo, e.g. "/assets/images/logo.png"
 # Build settings
 markdown: kramdown
 theme: jekyll-theme-basically-basic
-gems:
+plugins:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-sitemap


### PR DESCRIPTION
When trying to run `jekyll serve`, a deprecation notice shows up:

```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```

This change was required due to https://github.com/jekyll/jekyll/pull/5130.

Source: https://stackoverflow.com/questions/45122373/the-gems-configuration-option-has-been-renamed-to-plugins