### PR TITLE
Change id for primary nav to #primary-nav

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,4 +1,4 @@
-<nav id="nav-primary" class="site-nav" itemscope itemtype="http://schema.org/SiteNavigationElement" aria-label="Main navigation">
+<nav id="primary-nav" class="site-nav" itemscope itemtype="http://schema.org/SiteNavigationElement" aria-label="Main navigation">
   <ul id="menu-main-navigation" class="menu">
     <!-- Home link -->
     <li class="menu-item">


### PR DESCRIPTION
The skip to primary navigation links were not working as they referenced an incorrect anchor ID.