### PR TITLE
Update seo-tag gem to use latest versions.

### DIFF
--- a/jekyll-theme-basically-basic.gemspec
+++ b/jekyll-theme-basically-basic.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", "~> 3.3"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.8"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
-  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.4", ">= 2.3"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
Just a minor update to the gemspec to enforce `jekyll-seo-tag` versions greater than 2.3.