### PR TITLE
Fix JavaScript error when search is not enabled

### DIFF
--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -60,9 +60,11 @@ myMenu.addEventListener('click', function () {
   toggleClassMenu();
   animateMenuItems();
 }, false);
-mySearchToggle.addEventListener('click', function () {
-  toggleClassSearch();
-}, false);
+if (mySearchToggle) {
+  mySearchToggle.addEventListener('click', function () {
+    toggleClassSearch();
+  }, false);
+}
 
 // Toggle search input and content visibility
 function toggleClassSearch() {


### PR DESCRIPTION
Check `mySearchToggle` exists before calling `addEventListener()` to prevent error when search toggle does not exist ie. when search is not enabled.