### PR TITLE
Update icon-gitlab.html - Added the missing forward slash from the url.

### DIFF
--- a/_includes/icon-gitlab.html
+++ b/_includes/icon-gitlab.html
@@ -1,4 +1,4 @@
-<a href="https://gitlab.com{{ include.username }}">
+<a href="https://gitlab.com/{{ include.username }}">
   <span class="icon icon--gitlab">{% include icon-gitlab.svg %}</span>
   <span class="label">{{ include.label | default: include.username }}</span>
 </a>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/jekyll-theme-basically-basic#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

The missing `/` was causing the url to be incorrect in the finally generated web page.
The url got rendered as https://gitlab.comusername instead of https://gitlab.com/username