### PR TITLE
Remove stray console.log from lunr-search-scripts

### DIFF
--- a/_includes/search/lunr-search-scripts.html
+++ b/_includes/search/lunr-search-scripts.html
@@ -69,8 +69,6 @@
       }
     });
 
-    console.log(jQuery.type(idx));
-
     $(document).ready(function () {
       $('input#search').on('keyup', function () {
         var resultdiv = $('#results');


### PR DESCRIPTION
This is a small enhancement.

## Summary

There's a stray console.log in the lunr-search-scripts.html code from e94ea30 ([this line](https://github.com/mmistakes/jekyll-theme-basically-basic/commit/e94ea30ffd3156449a54a63bf65d23d241b94487#diff-be69d35cf3b8f84aa17e8cc78ac5711fR71)) that just outputs "object" into the console.