### PR TITLE
Adds support for front matter image captions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ algolia:
 
 # Build settings
 markdown: kramdown
-theme: jekyll-theme-basically-basic
+# theme: jekyll-theme-basically-basic
 plugins: # previsously gems
   - jekyll-feed
   - jekyll-seo-tag

--- a/_includes/page-intro.html
+++ b/_includes/page-intro.html
@@ -7,6 +7,8 @@
     {% assign intro_image = intro_image | escape %}
     <div class="intro-image">
       <img src="{{ intro_image }}" alt="{{ page.title }}">
+     {% if page.image.caption %}<span class="image-caption">{{ page.image.caption | markdownify | strip_newlines | remove: "<p>" | remove: "</p>" }}</span>{% endif %}
+    </div>
     </div>
   {% endif %}
 

--- a/_sass/basically-basic/_intro.scss
+++ b/_sass/basically-basic/_intro.scss
@@ -28,6 +28,30 @@
   img {
     width: 100%;
   }
+  .image-caption {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    margin: 0 auto;
+    padding: 2px 5px;
+    color: #fff;
+    font-family: $base-font-family;
+    font-size: $min-font-size;
+    background: #000;
+    text-align: right;
+    z-index: 5;
+    opacity: 0.5;
+    border-radius: $border-radius 0 0 0;
+  
+    @include breakpoint($large) {
+      padding: 5px 10px;
+    }
+  
+    a {
+      color: #fff;
+      text-decoration: none;
+    }
+  }
 }
 
 .intro-text {

--- a/_sass/basically-basic/_print.scss
+++ b/_sass/basically-basic/_print.scss
@@ -235,6 +235,18 @@
     color: #000;
   }
 
+  .intro-image {
+    .image-caption {
+      color: #000 !important;
+      background: #fff !important;
+      opacity: 1;
+
+      a {
+        color: #000 !important;
+      }
+    }
+  }
+
 /*
    Hide the following elements on print
    ========================================================================== */

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -13,3 +13,5 @@ group :jekyll_plugins do
 end
 
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
+
+gem "webrick", "~> 1.7"

--- a/example/_posts/2012-03-14-layout-hero-image.md
+++ b/example/_posts/2012-03-14-layout-hero-image.md
@@ -1,6 +1,8 @@
 ---
 title: "Layout: Hero Image"
-image: /assets/images/eder-oliveira-180877.jpg
+image: 
+  path: /assets/images/eder-oliveira-180877.jpg
+  caption: "Right [here](https://apple.com)"
 categories:
   - Layout
 tags:


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Adds the ability to display image caption text when present in the post front matter

## Context

As per ticket Basically Basic’s ticket, [#101](https://github.com/mmistakes/jekyll-theme-basically-basic/issues/101) Theme author said he wasn’t adding caption support. Since I see caption support as essential and I wanted to try to contribute back to the project by adding support for the inclusion of the caption task into the DOM, and add the supporting stylesheets, using jekyll theme rendering and SCSS methods similar to what the author used in his Minimal Mistakes theme.