### PR TITLE
Display 'Posts' header only if the site has posts

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,22 +7,25 @@ layout: default
 <main id="main" class="page-content" aria-label="Content">
   <div class="index inner">
     <div>{{ content }}</div>
-
-    <div>
-      <header class="section-title">
-        <h2>{{ site.data.theme.t.posts | default: 'Posts' }}{% if paginator.page > 1 %}{{ site.data.theme.t.page | default: 'Page' | prepend: ' - ' | append: ' ' }}{{ paginator.page }} {{ site.data.theme.t.of | default: 'of' }} {{ paginator.total_pages }}{% endif %}</h2>
-      </header>
-      <div class="entries-{{ page.entries_layout | default: 'list' }}">
-        {% if site.plugins contains 'jekyll-paginate' and page.paginate or site.gems contains 'jekyll-paginate' and page.paginate %}
-          {% comment %}
-            Add paginator.posts loop if jekyll-paginate plugin is enabled
-            and page.paginate == true
-          {% endcomment %}
-          {% include posts-paginated.html %}
-        {% else %}
-          {% include posts-all.html %}
-        {% endif %}
-      </div>
-    </div>
+    
+    {% if site.posts.size > 0 %}
+      <div>
+        <header class="section-title">
+          <h2>{{ site.data.theme.t.posts | default: 'Posts' }}{% if paginator.page > 1 %}{{ site.data.theme.t.page | default: 'Page' | prepend: ' - ' | append: ' ' }}{{ paginator.page }} {{ site.data.theme.t.of | default: 'of' }} {{ paginator.total_pages }}{% endif %}</h2>
+        </header>
+        <div class="entries-{{ page.entries_layout | default: 'list' }}">
+          {% if site.plugins contains 'jekyll-paginate' and page.paginate or site.gems contains 'jekyll-paginate' and page.paginate %}
+            {% comment %}
+              Add paginator.posts loop if jekyll-paginate plugin is enabled
+              and page.paginate == true
+            {% endcomment %}
+            {% include posts-paginated.html %}
+          {% else %}
+            {% include posts-all.html %}
+          {% endif %}
+        </div>
+      </div>    
+    {% endif %}
+    
   </div>
 </main>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/jekyll-theme-basically-basic#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

Display the 'Posts' section only if there are posts available.

<!--
  Provide a description of what your pull request changes.
-->

## Context

Currently, there is no check whether there are posts available or not.  
Due to this, even if there are no posts, still the 'Posts' header was visible.  
So I added a check to display the posts section only if the site has posts available.
<!--
  Is this related to any GitHub issue(s)?
-->
